### PR TITLE
change: switch to Font Awesome icons

### DIFF
--- a/app/(views)/[view]/page.tsx
+++ b/app/(views)/[view]/page.tsx
@@ -547,13 +547,17 @@ const handleTaskClick = async (task: Task) => {
                       {group.title && (
                         <div className="group-header">
                           <div className="group-title">
-                            {group.kind === "project" && <ProjectIcon />}
-                            {group.kind === "area" && <AreaIcon />}
+                            {group.kind === "project" && (
+                              <i className="fa-solid fa-tachometer icon-project" aria-hidden />
+                            )}
+                            {group.kind === "area" && (
+                              <i className="fa-solid fa-cube icon-area" aria-hidden />
+                            )}
                             {group.title}
                           </div>
                           {group.href && (
                             <a className="chevron-link" href={group.href} aria-label="Open">
-                              <ChevronIcon />
+                              <i className="fa-solid fa-chevron-right" aria-hidden />
                             </a>
                           )}
                         </div>
@@ -914,11 +918,11 @@ function TaskList({
                           className="icon-button"
                           onClick={() => setIsEditScheduleOpen(!isEditScheduleOpen)}
                         >
-                          <CalendarIcon />
+                          <i className="fa-solid fa-calendar icon-upcoming" aria-hidden />
                         </button>
                       )}
                       <button className="icon-button" type="button">
-                        <ChecklistIcon />
+                        <i className="fa-solid fa-list-check" aria-hidden />
                       </button>
                     </div>
                   </div>
@@ -939,7 +943,7 @@ function TaskList({
                         setIsEditScheduleOpen(false);
                       }}
                     >
-                      <MoonIcon />
+                      <i className="fa-solid fa-moon" aria-hidden />
                       This Evening
                     </button>
                     <InlineCalendar
@@ -957,7 +961,7 @@ function TaskList({
                         setIsEditScheduleOpen(false);
                       }}
                     >
-                      <SparkIcon />
+                      <i className="fa-solid fa-archive icon-someday" aria-hidden />
                       Someday
                     </button>
                   </div>
@@ -1228,143 +1232,28 @@ function startOfWeekNumber(value: string) {
   return Math.floor(date.getTime() / 86400000);
 }
 
-function CalendarIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M7 3v3M17 3v3M4 9h16M5 6h14a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function ChecklistIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="m4 7 2 2 4-4M4 15 6 17 10 13M14 7h6M14 15h6"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function MoonIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M21 14.5A8.5 8.5 0 1 1 9.5 3a7 7 0 1 0 11.5 11.5Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function SparkIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M12 2v6m0 8v6M2 12h6m8 0h6M5 5l4 4m6 6 4 4M19 5l-4 4m-6 6-4 4"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
 function DateBadge({ label }: { label: string }) {
-  if (label === "Today") {
-    return (
-      <span className="date-badge date-today">
-        <SunIcon />
-        Today
-      </span>
-    );
-  }
-  if (label === "This Evening") {
-    return (
-      <span className="date-badge date-evening">
-        <MoonIcon />
-        This Evening
-      </span>
-    );
-  }
-  if (label === "Someday") {
-    return (
-      <span className="date-badge date-someday">
-        <SparkIcon />
-        Someday
-      </span>
-    );
-  }
-  return <span className="date-badge">{label}</span>;
-}
-
-function AreaIcon() {
+  const iconClass =
+    label === "Today"
+      ? "fa-star icon-today"
+      : label === "This Evening"
+        ? "fa-moon date-evening"
+        : label === "Someday"
+          ? "fa-archive icon-someday"
+          : "fa-calendar icon-upcoming";
+  const badgeClass =
+    label === "Today"
+      ? "date-badge date-today"
+      : label === "This Evening"
+        ? "date-badge date-evening"
+        : label === "Someday"
+          ? "date-badge date-someday"
+          : "date-badge";
   return (
-    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M4 10l8-6 8 6v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-8Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function ProjectIcon() {
-  return (
-    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M4 7h6l2 2h8v8a2 2 0 0 1-2 2H4V7Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function ChevronIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="m9 6 6 6-6 6"
-        stroke="currentColor"
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function SunIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M12 3v2m0 14v2m9-9h-2M5 12H3m14.95 6.95-1.41-1.41M8.46 8.46 7.05 7.05m10.49 0-1.41 1.41M8.46 15.54l-1.41 1.41M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
+    <span className={badgeClass}>
+      <i className={`fa-solid ${iconClass}`} aria-hidden />
+      {label}
+    </span>
   );
 }
 

--- a/app/areas/[areaId]/page.tsx
+++ b/app/areas/[areaId]/page.tsx
@@ -601,11 +601,11 @@ function TaskList({
                           className="icon-button"
                           onClick={() => setIsEditScheduleOpen(!isEditScheduleOpen)}
                         >
-                          <CalendarIcon />
+                          <i className="fa-solid fa-calendar icon-upcoming" aria-hidden />
                         </button>
                       )}
                       <button className="icon-button" type="button">
-                        <ChecklistIcon />
+                        <i className="fa-solid fa-list-check" aria-hidden />
                       </button>
                     </div>
                   </div>
@@ -626,7 +626,7 @@ function TaskList({
                         setIsEditScheduleOpen(false);
                       }}
                     >
-                      <MoonIcon />
+                      <i className="fa-solid fa-moon" aria-hidden />
                       This Evening
                     </button>
                     <InlineCalendar
@@ -644,7 +644,7 @@ function TaskList({
                         setIsEditScheduleOpen(false);
                       }}
                     >
-                      <SparkIcon />
+                      <i className="fa-solid fa-archive icon-someday" aria-hidden />
                       Someday
                     </button>
                   </div>
@@ -719,101 +719,28 @@ function TaskDateBadge({
   return <DateBadge label={label} />;
 }
 
-function CalendarIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M7 3v3M17 3v3M4 9h16M5 6h14a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function ChecklistIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="m4 7 2 2 4-4M4 15 6 17 10 13M14 7h6M14 15h6"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function MoonIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M21 14.5A8.5 8.5 0 1 1 9.5 3a7 7 0 1 0 11.5 11.5Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function SparkIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M12 2v6m0 8v6M2 12h6m8 0h6M5 5l4 4m6 6 4 4M19 5l-4 4m-6 6-4 4"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
 function DateBadge({ label }: { label: string }) {
-  if (label === "Today") {
-    return (
-      <span className="date-badge date-today">
-        <SunIcon />
-        Today
-      </span>
-    );
-  }
-  if (label === "This Evening") {
-    return (
-      <span className="date-badge date-evening">
-        <MoonIcon />
-        This Evening
-      </span>
-    );
-  }
-  if (label === "Someday") {
-    return (
-      <span className="date-badge date-someday">
-        <SparkIcon />
-        Someday
-      </span>
-    );
-  }
-  return <span className="date-badge">{label}</span>;
-}
-
-function SunIcon() {
+  const iconClass =
+    label === "Today"
+      ? "fa-star icon-today"
+      : label === "This Evening"
+        ? "fa-moon date-evening"
+        : label === "Someday"
+          ? "fa-archive icon-someday"
+          : "fa-calendar icon-upcoming";
+  const badgeClass =
+    label === "Today"
+      ? "date-badge date-today"
+      : label === "This Evening"
+        ? "date-badge date-evening"
+        : label === "Someday"
+          ? "date-badge date-someday"
+          : "date-badge";
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M12 3v2m0 14v2m9-9h-2M5 12H3m14.95 6.95-1.41-1.41M8.46 8.46 7.05 7.05m10.49 0-1.41 1.41M8.46 15.54l-1.41 1.41M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
+    <span className={badgeClass}>
+      <i className={`fa-solid ${iconClass}`} aria-hidden />
+      {label}
+    </span>
   );
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Fraunces:opsz,wght@9..144,600;700&display=swap");
+@import "@fortawesome/fontawesome-free/css/all.min.css";
 
 /* CSS reset */
 *,
@@ -693,14 +694,10 @@ textarea.note-input {
 .date-badge {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-size: 12px;
+  gap: 8px;
+  font-size: 16px;
+  line-height: 1.4;
   color: var(--muted);
-}
-
-.date-badge svg {
-  width: 16px;
-  height: 16px;
 }
 
 .date-today {
@@ -808,12 +805,24 @@ textarea.note-input {
   font-weight: 600;
 }
 
+.icon-project {
+  color: #6a7ea5;
+}
+
+.icon-area {
+  color: #d98a2b;
+}
+
+.icon-inbox {
+  color: #3b4d7a;
+}
+
 .icon-today {
   color: #d98a2b;
 }
 
 .icon-upcoming {
-  color: #6a7ea5;
+  color: #bd5e4a;
 }
 
 .icon-anytime {
@@ -821,15 +830,11 @@ textarea.note-input {
 }
 
 .icon-someday {
-  color: #5b7a4f;
+  color: #6b5f4f;
 }
 
 .icon-logbook {
-  color: #7a5d4a;
-}
-
-.icon-inbox {
-  color: #bd5e4a;
+  color: #5b7a4f;
 }
 
 .date-group {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -136,31 +136,31 @@ export default function HomePage() {
           status={today.status}
           detail={`Overdue ${todayCount.overdue} / Today ${todayCount.rest}`}
           showDetail={today.status === "ready"}
-          icon={<SunIcon className="icon-today" />}
+          icon={<i className="fa-solid fa-star icon-today" aria-hidden />}
         />
         <CategoryCard
           title="Upcoming"
           href="/upcoming"
           status={today.status}
-          icon={<CalendarIcon className="icon-upcoming" />}
+          icon={<i className="fa-solid fa-calendar icon-upcoming" aria-hidden />}
         />
         <CategoryCard
           title="Anytime"
           href="/anytime"
           status={today.status}
-          icon={<InfinityIcon className="icon-anytime" />}
+          icon={<i className="fa-brands fa-stack-overflow icon-anytime" aria-hidden />}
         />
         <CategoryCard
           title="Someday"
           href="/someday"
           status={today.status}
-          icon={<SparkIcon className="icon-someday" />}
+          icon={<i className="fa-solid fa-archive icon-someday" aria-hidden />}
         />
         <CategoryCard
           title="Logbook"
           href="/logbook"
           status={today.status}
-          icon={<ArchiveIcon className="icon-logbook" />}
+          icon={<i className="fa-solid fa-book icon-logbook" aria-hidden />}
         />
         <CategoryCard
           title="Inbox"
@@ -168,7 +168,7 @@ export default function HomePage() {
           status={inbox.status}
           detail={`Overdue ${inboxCount.overdue} / Others ${inboxCount.rest}`}
           showDetail={inbox.status === "ready"}
-          icon={<InboxIcon className="icon-inbox" />}
+          icon={<i className="fa-solid fa-inbox icon-inbox" aria-hidden />}
         />
         {areas.status === "loading" && <CategoryCard title="Areas" status="loading" />}
         {areas.status === "error" && (
@@ -249,89 +249,5 @@ function CategoryCard({
     </a>
   ) : (
     body
-  );
-}
-
-function CalendarIcon({ className }: { className?: string }) {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden className={className}>
-      <path
-        d="M7 3v3M17 3v3M4 9h16M5 6h14a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function SunIcon({ className }: { className?: string }) {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden className={className}>
-      <path
-        d="M12 3v2m0 14v2m9-9h-2M5 12H3m14.95 6.95-1.41-1.41M8.46 8.46 7.05 7.05m10.49 0-1.41 1.41M8.46 15.54l-1.41 1.41M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function SparkIcon({ className }: { className?: string }) {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden className={className}>
-      <path
-        d="M12 2v6m0 8v6M2 12h6m8 0h6M5 5l4 4m6 6 4 4M19 5l-4 4m-6 6-4 4"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function ArchiveIcon({ className }: { className?: string }) {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden className={className}>
-      <path
-        d="M3 7h18M5 7l1-3h12l1 3M6 7v11a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7M9 11h6"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function InboxIcon({ className }: { className?: string }) {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden className={className}>
-      <path
-        d="M4 5h16l2 8v6H2v-6l2-8Zm0 8h5l2 3h2l2-3h5"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function InfinityIcon({ className }: { className?: string }) {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden className={className}>
-      <path
-        d="M7.5 9.5c-2 0-3.5 1.6-3.5 3.5S5.5 16.5 7.5 16.5c1.4 0 2.6-.7 4.5-2.5 1.9-1.8 3.1-2.5 4.5-2.5 2 0 3.5 1.6 3.5 3.5s-1.5 3.5-3.5 3.5c-1.4 0-2.6-.7-4.5-2.5-1.9-1.8-3.1-2.5-4.5-2.5Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
   );
 }

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -608,11 +608,11 @@ function TaskList({
                           className="icon-button"
                           onClick={() => setIsEditScheduleOpen(!isEditScheduleOpen)}
                         >
-                          <CalendarIcon />
+                          <i className="fa-solid fa-calendar icon-upcoming" aria-hidden />
                         </button>
                       )}
                       <button className="icon-button" type="button">
-                        <ChecklistIcon />
+                        <i className="fa-solid fa-list-check" aria-hidden />
                       </button>
                     </div>
                   </div>
@@ -633,7 +633,7 @@ function TaskList({
                         setIsEditScheduleOpen(false);
                       }}
                     >
-                      <MoonIcon />
+                      <i className="fa-solid fa-moon" aria-hidden />
                       This Evening
                     </button>
                     <InlineCalendar
@@ -651,7 +651,7 @@ function TaskList({
                         setIsEditScheduleOpen(false);
                       }}
                     >
-                      <SparkIcon />
+                      <i className="fa-solid fa-archive icon-someday" aria-hidden />
                       Someday
                     </button>
                   </div>
@@ -726,101 +726,28 @@ function TaskDateBadge({
   return <DateBadge label={label} />;
 }
 
-function CalendarIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M7 3v3M17 3v3M4 9h16M5 6h14a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function ChecklistIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="m4 7 2 2 4-4M4 15 6 17 10 13M14 7h6M14 15h6"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function MoonIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M21 14.5A8.5 8.5 0 1 1 9.5 3a7 7 0 1 0 11.5 11.5Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function SparkIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M12 2v6m0 8v6M2 12h6m8 0h6M5 5l4 4m6 6 4 4M19 5l-4 4m-6 6-4 4"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
 function DateBadge({ label }: { label: string }) {
-  if (label === "Today") {
-    return (
-      <span className="date-badge date-today">
-        <SunIcon />
-        Today
-      </span>
-    );
-  }
-  if (label === "This Evening") {
-    return (
-      <span className="date-badge date-evening">
-        <MoonIcon />
-        This Evening
-      </span>
-    );
-  }
-  if (label === "Someday") {
-    return (
-      <span className="date-badge date-someday">
-        <SparkIcon />
-        Someday
-      </span>
-    );
-  }
-  return <span className="date-badge">{label}</span>;
-}
-
-function SunIcon() {
+  const iconClass =
+    label === "Today"
+      ? "fa-star icon-today"
+      : label === "This Evening"
+        ? "fa-moon date-evening"
+        : label === "Someday"
+          ? "fa-archive icon-someday"
+          : "fa-calendar icon-upcoming";
+  const badgeClass =
+    label === "Today"
+      ? "date-badge date-today"
+      : label === "This Evening"
+        ? "date-badge date-evening"
+        : label === "Someday"
+          ? "date-badge date-someday"
+          : "date-badge";
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path
-        d="M12 3v2m0 14v2m9-9h-2M5 12H3m14.95 6.95-1.41-1.41M8.46 8.46 7.05 7.05m10.49 0-1.41 1.41M8.46 15.54l-1.41 1.41M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
+    <span className={badgeClass}>
+      <i className={`fa-solid ${iconClass}`} aria-hidden />
+      {label}
+    </span>
   );
 }
 

--- a/docs/L2_development/style_guidelines.md
+++ b/docs/L2_development/style_guidelines.md
@@ -12,8 +12,27 @@
 ### カラー / テーマ
 - `:root` の CSS 変数で色と影を定義（`--bg`, `--ink`, `--muted`, `--accent`, `--accent-2`, `--card`, `--border`, `--shadow`）
 - ページ背景は淡色グラデーションを採用（`html, body`）
+- アイコンは Font Awesome 6（npm）を利用
 
 根拠: `app/globals.css`
+
+### アイコン運用
+- 主要カテゴリは Font Awesome 6 の固定アイコンと固定色を使用
+- Project: `fa-tachometer` + `.icon-project`（`#6a7ea5`）
+- Area: `fa-cube` + `.icon-area`（`#d98a2b`）
+- Inbox: `fa-inbox` + `.icon-inbox`（`#3b4d7a`）
+- Today: `fa-star` + `.icon-today`（`#d98a2b`）
+- Upcoming: `fa-calendar` + `.icon-upcoming`（`#bd5e4a`）
+- Anytime: `fa-stack-overflow` + `.icon-anytime`（`#3f6b5f`）
+- Someday: `fa-archive` + `.icon-someday`（`#6b5f4f`）
+- Logbook: `fa-book` + `.icon-logbook`（`#5b7a4f`）
+- タスク詳細の日付表示（`.date-badge`）は 16px で、ラベルに応じて左側アイコンを切り替える
+- `Today`: `fa-star`（`.icon-today`）
+- `This Evening`: `fa-moon`（`.date-evening`）
+- `Someday`: `fa-archive`（`.icon-someday`）
+- その他: `fa-calendar`（`.icon-upcoming`）
+
+根拠: `app/page.tsx`, `app/(views)/[view]/page.tsx`, `app/areas/[areaId]/page.tsx`, `app/projects/[projectId]/page.tsx`, `app/globals.css`
 
 ### カラー詳細（HEX）
 - メインカラー（Text/Inks）: `#1b1a16`（`--ink`）
@@ -76,7 +95,7 @@
 - カード表現: `.view-card`, `.view-header`, `.badge`, `.detail`, `.card-link`
 - タイトル装飾: `.with-icon`, `.title-icon`
 - ステータス文言: `.error`, `.muted`, `.hint`
-- カテゴリアイコン: `.icon-today`, `.icon-upcoming`, `.icon-anytime`, `.icon-someday`, `.icon-logbook`, `.icon-inbox`
+- カテゴリアイコン: `.icon-project`, `.icon-area`, `.icon-today`, `.icon-upcoming`, `.icon-anytime`, `.icon-someday`, `.icon-logbook`, `.icon-inbox`
 
 根拠: `app/page.tsx`, `app/globals.css`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "nextstep",
       "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.7.2",
         "@supabase/supabase-js": "^2.45.4",
         "next": "^15.1.6",
         "react": "^19.0.0",
@@ -416,6 +417,15 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@img/colour": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:integration": "INTEGRATION_TEST=1 vitest run tests/integration"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.7.2",
     "@supabase/supabase-js": "^2.45.4",
     "next": "^15.1.6",
     "react": "^19.0.0",


### PR DESCRIPTION
## 作業内容概要
- SVGアイコンをFont Awesome 6へ置換
- カテゴリ/日付の固定色ルールを適用
- タスク詳細の日付バッジを16pxにし、ラベルに応じて左側アイコンを切替

## 変更ファイルごとの修正内容となぜその修正を行ったのかの理由
- app/page.tsx: HomeカテゴリのアイコンをFAへ置換（SVG廃止と固定色ルール適用のため）
- app/(views)/[view]/page.tsx: グループ/操作/日付バッジのアイコンをFAへ置換し、日付ラベル別のアイコン切替を実装（仕様統一と日付表示要件のため）
- app/areas/[areaId]/page.tsx: 予定編集と日付バッジのアイコンをFAへ置換、日付ラベル別のアイコン切替を実装（仕様統一のため）
- app/projects/[projectId]/page.tsx: 予定編集と日付バッジのアイコンをFAへ置換、日付ラベル別のアイコン切替を実装（仕様統一のため）
- app/globals.css: Font Awesome読み込み、アイコン色クラス更新、date-badgeのサイズ調整（固定色と日付表示要件のため）
- docs/L2_development/style_guidelines.md: FA運用・固定色・日付バッジ仕様を追記（仕様の明文化のため）
- package.json / package-lock.json: Font Awesome依存を追加（FA利用のため）

## 留意点
- テスト: npm run test
- Font Awesome 6 free iconsのみ使用