### PR TITLE
Today/Area/Project: overdue tasks show fa-flag Nd ago

### DIFF
--- a/app/(views)/[view]/page.tsx
+++ b/app/(views)/[view]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
+import { formatOverdueDaysAgo } from "../../_lib/overdue";
 import { sortDatedByDateAscThenCreatedDesc, sortMixedByDateAndCreated } from "../../_lib/task_sort";
 
 type Task = {
@@ -1111,6 +1112,9 @@ function TaskList({
                 </div>
               </div>
               <div className="task-meta">
+                {item.date && isDateBefore(item.date, today) ? (
+                  <TaskDateBadge task={item} today={today} eveningMap={eveningMap} />
+                ) : null}
                 <div className="row-actions" />
               </div>
             </div>
@@ -1485,8 +1489,8 @@ function formatRelativeDateLabel(date: string, today: string) {
     const month = target.month + 1;
     return { text: `${month}/${target.day}(${weekday})`, isPast: false };
   }
-  const month = target.month + 1;
-  return { text: `${month}/${target.day}(${weekday})`, isPast: true };
+  const overdueText = formatOverdueDaysAgo(date, today);
+  return { text: overdueText ?? `${target.month + 1}/${target.day}(${weekday})`, isPast: true };
 }
 
 function dateToNumber(value: string) {

--- a/app/_lib/overdue.ts
+++ b/app/_lib/overdue.ts
@@ -1,0 +1,25 @@
+function parseDateString(value: string) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+  return { year, month, day };
+}
+
+function dateToNumber(value: string) {
+  const parsed = parseDateString(value);
+  if (!parsed) return null;
+  return Math.floor(Date.UTC(parsed.year, parsed.month, parsed.day) / 86400000);
+}
+
+export function formatOverdueDaysAgo(date: string, today: string) {
+  const dateNum = dateToNumber(date);
+  const todayNum = dateToNumber(today);
+  if (dateNum === null || todayNum === null) return null;
+  const diff = todayNum - dateNum;
+  if (diff <= 0) return null;
+  return `${diff}d ago`;
+}
+

--- a/app/areas/[areaId]/page.tsx
+++ b/app/areas/[areaId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
+import { formatOverdueDaysAgo } from "../../_lib/overdue";
 import { sortMixedByDateAndCreated } from "../../_lib/task_sort";
 
 type Task = {
@@ -766,6 +767,9 @@ function TaskList({
                 </div>
               </div>
               <div className="task-meta">
+                {item.date && isDateBefore(item.date, today) ? (
+                  <TaskDateBadge task={item} today={today} eveningMap={eveningMap} />
+                ) : null}
                 <div className="row-actions" />
               </div>
             </div>
@@ -958,8 +962,8 @@ function formatRelativeDateLabel(date: string, today: string) {
     const month = target.month + 1;
     return { text: `${month}/${target.day}(${weekday})`, isPast: false };
   }
-  const month = target.month + 1;
-  return { text: `${month}/${target.day}(${weekday})`, isPast: true };
+  const overdueText = formatOverdueDaysAgo(date, today);
+  return { text: overdueText ?? `${target.month + 1}/${target.day}(${weekday})`, isPast: true };
 }
 
 function dateToNumber(value: string) {

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
+import { formatOverdueDaysAgo } from "../../_lib/overdue";
 import { sortMixedByDateAndCreated } from "../../_lib/task_sort";
 
 type Task = {
@@ -773,6 +774,9 @@ function TaskList({
                 </div>
               </div>
               <div className="task-meta">
+                {item.date && isDateBefore(item.date, today) ? (
+                  <TaskDateBadge task={item} today={today} eveningMap={eveningMap} />
+                ) : null}
                 <div className="row-actions" />
               </div>
             </div>
@@ -965,8 +969,8 @@ function formatRelativeDateLabel(date: string, today: string) {
     const month = target.month + 1;
     return { text: `${month}/${target.day}(${weekday})`, isPast: false };
   }
-  const month = target.month + 1;
-  return { text: `${month}/${target.day}(${weekday})`, isPast: true };
+  const overdueText = formatOverdueDaysAgo(date, today);
+  return { text: overdueText ?? `${target.month + 1}/${target.day}(${weekday})`, isPast: true };
 }
 
 function dateToNumber(value: string) {

--- a/tests/overdue.test.ts
+++ b/tests/overdue.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatOverdueDaysAgo } from "../app/_lib/overdue";
+
+describe("formatOverdueDaysAgo", () => {
+  it("returns 1d ago for yesterday", () => {
+    expect(formatOverdueDaysAgo("2026-02-05", "2026-02-06")).toBe("1d ago");
+  });
+
+  it("returns 6d ago for six days old date", () => {
+    expect(formatOverdueDaysAgo("2026-01-31", "2026-02-06")).toBe("6d ago");
+  });
+
+  it("returns null for today", () => {
+    expect(formatOverdueDaysAgo("2026-02-06", "2026-02-06")).toBeNull();
+  });
+
+  it("returns null for future date", () => {
+    expect(formatOverdueDaysAgo("2026-02-07", "2026-02-06")).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## 作業内容概要
- Today/Area/Project のタスク一覧で、今日より過去の日付タスクを右端に `fa-flag` + `Nd ago` で表示するように変更
- 過去日付表示の `Nd ago` 生成ロジックを共通化
- 単体テストを追加

## 変更ファイルごとの修正内容と理由
- `app/(views)/[view]/page.tsx`
  - 右端メタ領域に過去日付タスクの `TaskDateBadge` を描画
  - 過去日付のラベルを `Nd ago` 優先に変更
  - 理由: `/today` ビューで要件どおりに視認可能にするため
- `app/areas/[areaId]/page.tsx`
  - 同上
  - 理由: Area 画面も対象に含める要件対応
- `app/projects/[projectId]/page.tsx`
  - 同上
  - 理由: Project 画面も対象に含める要件対応
- `app/_lib/overdue.ts`
  - `formatOverdueDaysAgo(date, today)` を新規追加
  - 理由: 3画面で同一ロジックを使い回して差異を防ぐため
- `tests/overdue.test.ts`
  - `1d ago` / `6d ago` / 今日 / 未来日のケースを追加
  - 理由: `Nd ago` 計算ロジックの回帰防止

## 留意点
- `Nd ago` 表示は `date < today` の場合のみ表示
- `Today` / `This Evening` / `Someday` / 未来日表示ルールは維持
