### PR TITLE
docs: align overdue date notation in specifications

### DIFF
--- a/docs/L2_development/style_guidelines.md
+++ b/docs/L2_development/style_guidelines.md
@@ -35,7 +35,7 @@
   - 明日: `Tomorrow`
   - 今日から2〜5日後: 曜日（例: `Mon`）
   - 6日後以降: `m/d(曜日)`（ゼロ埋めなし）
-  - 過去日付: `m/d(曜日)` + `fa-flag`、文字色は紫（`.date-overdue`）
+  - 過去日付: `Nd ago` + `fa-flag`、文字色は紫（`.date-overdue`）
 
 根拠: `app/page.tsx`, `app/(views)/[view]/page.tsx`, `app/areas/[areaId]/page.tsx`, `app/projects/[projectId]/page.tsx`, `app/globals.css`
 

--- a/docs/L3_implementation/specification_summary.md
+++ b/docs/L3_implementation/specification_summary.md
@@ -43,8 +43,9 @@
 - Logbook: 完了日（`archived_at`）降順（変更なし）
 - Today: Project/Area/No Group の順で表示し、その後に This Evening を表示
 - Inbox/Anytime/Someday/Area/Project: 日付なし → 日付ありの順で並べ、日付なしは `created_at` 降順、日付ありは `date` 昇順 + `created_at` 降順
+- Today/Area/Project の一覧行では、`date < today` のタスクを右端メタ領域に `fa-flag` + `Nd ago`（紫）で表示する
 
-根拠: `app/(views)/[view]/page.tsx`, `app/areas/[areaId]/page.tsx`, `app/projects/[projectId]/page.tsx`
+根拠: `app/(views)/[view]/page.tsx`, `app/areas/[areaId]/page.tsx`, `app/projects/[projectId]/page.tsx`, `app/_lib/overdue.ts`
 
 ## Project / Area / Checklist
 - Project: `name` / `note` 必須。


### PR DESCRIPTION
- update style guideline to define overdue dates as "Nd ago" with a flag
- add overdue rendering rule for Today/Area/Project list rows
- append app/_lib/overdue.ts to the specification evidence list
