### PR TITLE
feat: improve navigation responsiveness and upcoming section utility

### DIFF
--- a/app/_components/CategoryCard.tsx
+++ b/app/_components/CategoryCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import Link from "next/link";
 
 type ViewStatus = "idle" | "loading" | "error" | "ready";
 
@@ -35,11 +36,5 @@ export function CategoryCard({
     </div>
   );
 
-  return href ? (
-    <a className="card-link" href={href}>
-      {body}
-    </a>
-  ) : (
-    body
-  );
+  return href ? <Link className="card-link" href={href}>{body}</Link> : body;
 }

--- a/app/_components/PageMidHeader.tsx
+++ b/app/_components/PageMidHeader.tsx
@@ -1,10 +1,12 @@
+import Link from "next/link";
+
 export function PageMidHeader({ title, href = "/" }: { title: string; href?: string }) {
   return (
     <section className="page-mid-header">
       <h1>
-        <a className="page-mid-header-link" href={href}>
+        <Link className="page-mid-header-link" href={href}>
           <i className="fa-solid fa-arrow-circle-left" aria-hidden="true" /> {title}
-        </a>
+        </Link>
       </h1>
     </section>
   );

--- a/app/_lib/upcoming_sections.ts
+++ b/app/_lib/upcoming_sections.ts
@@ -1,0 +1,178 @@
+import { sortDatedByDateAscThenCreatedDesc } from "./task_sort";
+
+export type UpcomingTask = {
+  id: string;
+  date: string | null;
+  createdAt: string | null;
+};
+
+export type UpcomingSection =
+  | { key: string; kind: "day"; dayNumber: number; label: string; items: UpcomingTask[] }
+  | {
+      key: string;
+      kind: "range";
+      title: string;
+      monthLabel: string;
+      rangeLabel: string;
+      items: UpcomingTask[];
+    }
+  | { key: string; kind: "month"; title: string; items: UpcomingTask[] }
+  | { key: string; kind: "year"; title: string; items: UpcomingTask[] };
+
+export function buildUpcomingSections<T extends UpcomingTask>(
+  items: T[],
+  today: string
+): Array<UpcomingSection & { items: T[] }> {
+  const todayParts = parseDateString(today);
+  if (!todayParts) return [];
+
+  const byDate = new Map<string, T[]>();
+  for (const item of items) {
+    if (!item.date) continue;
+    if (!byDate.has(item.date)) byDate.set(item.date, []);
+    byDate.get(item.date)?.push(item);
+  }
+  for (const [date, list] of byDate.entries()) {
+    const sorted = sortDatedByDateAscThenCreatedDesc(list);
+    byDate.set(date, sorted);
+  }
+
+  const sections: Array<UpcomingSection & { items: T[] }> = [];
+  const todayNum = dateToNumber(today);
+
+  for (let diff = 1; diff <= 7; diff += 1) {
+    const date = numberToDateString(todayNum + diff);
+    const parsed = parseDateString(date);
+    if (!parsed) continue;
+    sections.push({
+      key: `day-${date}`,
+      kind: "day",
+      dayNumber: parsed.day,
+      label: getUpcomingDayLabel(date, today),
+      items: byDate.get(date) ?? [],
+    });
+  }
+
+  const rangeStart = numberToDateString(todayNum + 8);
+  const endOfCurrentMonth = formatDateString(
+    todayParts.year,
+    todayParts.month,
+    new Date(Date.UTC(todayParts.year, todayParts.month + 1, 0)).getUTCDate()
+  );
+  const rangeStartNum = dateToNumber(rangeStart);
+  const endOfCurrentMonthNum = dateToNumber(endOfCurrentMonth);
+  if (rangeStartNum <= endOfCurrentMonthNum) {
+    sections.push({
+      key: `range-${rangeStart}-${endOfCurrentMonth}`,
+      kind: "range",
+      title: `${formatMonthLong(todayParts.year, todayParts.month)} ${dateRangeLabel(rangeStart, endOfCurrentMonth)}`,
+      monthLabel: formatMonthLong(todayParts.year, todayParts.month),
+      rangeLabel: dateRangeLabel(rangeStart, endOfCurrentMonth),
+      items: collectItemsByRange(byDate, rangeStartNum, endOfCurrentMonthNum),
+    });
+  }
+
+  for (let monthOffset = 1; monthOffset <= 3; monthOffset += 1) {
+    const target = shiftMonth(todayParts.year, todayParts.month, monthOffset);
+    const monthStart = formatDateString(target.year, target.month, 1);
+    const monthEnd = formatDateString(
+      target.year,
+      target.month,
+      new Date(Date.UTC(target.year, target.month + 1, 0)).getUTCDate()
+    );
+    sections.push({
+      key: `month-${target.year}-${target.month}`,
+      kind: "month",
+      title: formatMonthLong(target.year, target.month),
+      items: collectItemsByRange(byDate, dateToNumber(monthStart), dateToNumber(monthEnd)),
+    });
+  }
+
+  const month4 = shiftMonth(todayParts.year, todayParts.month, 4);
+  const month4StartNum = dateToNumber(formatDateString(month4.year, month4.month, 1));
+  const yearGroups = new Map<number, T[]>();
+  for (const [date, list] of byDate.entries()) {
+    const num = dateToNumber(date);
+    if (num < month4StartNum) continue;
+    const parsed = parseDateString(date);
+    if (!parsed) continue;
+    if (!yearGroups.has(parsed.year)) yearGroups.set(parsed.year, []);
+    yearGroups.get(parsed.year)?.push(...list);
+  }
+  const sortedYears = [...yearGroups.keys()].sort((a, b) => a - b);
+  for (const year of sortedYears) {
+    sections.push({
+      key: `year-${year}`,
+      kind: "year",
+      title: String(year),
+      items: sortDatedByDateAscThenCreatedDesc(yearGroups.get(year) ?? []),
+    });
+  }
+
+  return sections;
+}
+
+function collectItemsByRange<T extends UpcomingTask>(
+  byDate: Map<string, T[]>,
+  startNum: number,
+  endNum: number
+) {
+  const rows: T[] = [];
+  for (const [date, list] of byDate.entries()) {
+    const num = dateToNumber(date);
+    if (num < startNum || num > endNum) continue;
+    rows.push(...list);
+  }
+  return sortDatedByDateAscThenCreatedDesc(rows);
+}
+
+function numberToDateString(dayNum: number) {
+  const date = new Date(dayNum * 86400000);
+  return formatDateString(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function getUpcomingDayLabel(date: string, today: string) {
+  const diff = dateToNumber(date) - dateToNumber(today);
+  if (diff === 1) return "Tomorrow";
+  return new Intl.DateTimeFormat("en-US", { weekday: "long" }).format(
+    new Date(`${date}T00:00:00Z`)
+  );
+}
+
+function formatMonthLong(year: number, month: number) {
+  return new Intl.DateTimeFormat("en-US", { month: "long" }).format(new Date(Date.UTC(year, month, 1)));
+}
+
+function dateRangeLabel(start: string, end: string) {
+  const s = parseDateString(start);
+  const e = parseDateString(end);
+  if (!s || !e) return "";
+  return `${s.day}\u2013${e.day}`;
+}
+
+function parseDateString(value: string) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+  return { year, month, day };
+}
+
+function dateToNumber(value: string) {
+  const parsed = parseDateString(value);
+  if (!parsed) return 0;
+  return Math.floor(Date.UTC(parsed.year, parsed.month, parsed.day) / 86400000);
+}
+
+function formatDateString(year: number, month: number, day: number) {
+  const mm = String(month + 1).padStart(2, "0");
+  const dd = String(day).padStart(2, "0");
+  return `${year}-${mm}-${dd}`;
+}
+
+function shiftMonth(year: number, month: number, delta: number) {
+  const next = new Date(Date.UTC(year, month + delta, 1));
+  return { year: next.getUTCFullYear(), month: next.getUTCMonth() };
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -918,7 +918,7 @@ textarea.note-input {
 }
 
 .upcoming-day-number {
-  font-size: 36px;
+  font-size: 28px;
   line-height: 1;
   font-weight: 700;
   color: #3e434a;

--- a/tests/upcoming_sectioning.test.ts
+++ b/tests/upcoming_sectioning.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildUpcomingSections } from "../app/(views)/[view]/page";
+import { buildUpcomingSections } from "../app/_lib/upcoming_sections";
 
 type Task = {
   id: string;
@@ -48,23 +48,39 @@ describe("upcoming sectioning", () => {
 
     expect(sections).toHaveLength(14);
     expect(sections.slice(0, 7).every((s) => s.kind === "day")).toBe(true);
-    expect(sections[0].kind).toBe("day");
-    expect(sections[0].label).toBe("Tomorrow");
-    expect(sections[0].dayNumber).toBe(9);
+    expect(sections[0]?.kind).toBe("day");
+    const first = sections[0];
+    if (!first || first.kind !== "day") throw new Error("first section must be day");
+    expect(first.label).toBe("Tomorrow");
+    expect(first.dayNumber).toBe(9);
 
-    expect(sections[7].kind).toBe("range");
-    expect(sections[7].title).toBe("February 16–28");
-    expect(sections[7].items.map((t) => t.id)).toEqual(["r1", "r2"]);
+    expect(sections[7]?.kind).toBe("range");
+    const range = sections[7];
+    if (!range || range.kind !== "range") throw new Error("8th section must be range");
+    expect(range.title).toBe("February 16–28");
+    expect(range.items.map((t) => t.id)).toEqual(["r1", "r2"]);
 
-    expect(sections[8].kind).toBe("month");
-    expect(sections[8].title).toBe("March");
-    expect(sections[9].title).toBe("April");
-    expect(sections[10].title).toBe("May");
+    expect(sections[8]?.kind).toBe("month");
+    const month1 = sections[8];
+    const month2 = sections[9];
+    const month3 = sections[10];
+    if (!month1 || month1.kind !== "month") throw new Error("9th section must be month");
+    if (!month2 || month2.kind !== "month") throw new Error("10th section must be month");
+    if (!month3 || month3.kind !== "month") throw new Error("11th section must be month");
+    expect(month1.title).toBe("March");
+    expect(month2.title).toBe("April");
+    expect(month3.title).toBe("May");
 
-    expect(sections[11].kind).toBe("year");
-    expect(sections[11].title).toBe("2026");
-    expect(sections[11].items.map((t) => t.id)).toEqual(["y0"]);
-    expect(sections[12].title).toBe("2027");
-    expect(sections[13].title).toBe("2028");
+    expect(sections[11]?.kind).toBe("year");
+    const year1 = sections[11];
+    const year2 = sections[12];
+    const year3 = sections[13];
+    if (!year1 || year1.kind !== "year") throw new Error("12th section must be year");
+    if (!year2 || year2.kind !== "year") throw new Error("13th section must be year");
+    if (!year3 || year3.kind !== "year") throw new Error("14th section must be year");
+    expect(year1.title).toBe("2026");
+    expect(year1.items.map((t) => t.id)).toEqual(["y0"]);
+    expect(year2.title).toBe("2027");
+    expect(year3.title).toBe("2028");
   });
 });


### PR DESCRIPTION
## Summary
- replace internal anchor links with next/link to avoid full page reload navigation
- remove redundant header fetches in view page and reuse current view payload for header counts
- extract upcoming section builder into shared utility for safer imports and page export constraints
- update upcoming sectioning test for shared utility import and strict type narrowing

## Validation
- npm run typecheck
- npm run test -- tests/upcoming_sectioning.test.ts