### PR TITLE
公開向けログインページ追加とトップ導線の /top 統一

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 bk_*
 temp_for_ai
 .env
+.env.zwc
 .next
 node_modules
 dist
 coverage
 .DS_Store
+supabase
 npm-debug.log
 yarn-error.log
 pnpm-debug.log

--- a/app/(views)/[view]/page.tsx
+++ b/app/(views)/[view]/page.tsx
@@ -647,7 +647,7 @@ const handleTaskClick = async (task: Task) => {
           <div className="panel">
             <h1>Not Found</h1>
             <p className="muted">このカテゴリは存在しません。</p>
-            <Link className="pill-link" href="/">
+            <Link className="pill-link" href="/top">
               Back
             </Link>
           </div>

--- a/app/_components/PageMidHeader.tsx
+++ b/app/_components/PageMidHeader.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-export function PageMidHeader({ title, href = "/" }: { title: string; href?: string }) {
+export function PageMidHeader({ title, href = "/top" }: { title: string; href?: string }) {
   return (
     <section className="page-mid-header">
       <h1>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { PageHero } from "../_components/PageHero";
+import { useClientAuth } from "../_hooks/useClientAuth";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const {
+    authProvider,
+    setAuthProvider,
+    isAuthenticated,
+    isAuthLoading,
+    authError,
+    login,
+    logout,
+    tzOffset,
+    setTzOffset,
+  } = useClientAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleLogin = async () => {
+    const ok = await login(email, password);
+    if (ok) {
+      setPassword("");
+      router.push("/top");
+    }
+  };
+
+  return (
+    <main>
+      <PageHero
+        eyebrow="Welcome"
+        title="Login"
+        lead="公開版をご利用いただくにはログインしてください。"
+      />
+
+      <section className="grid">
+        <div className="panel">
+          {!isAuthenticated ? (
+            <>
+              <label>
+                Login Method
+                <select
+                  value={authProvider}
+                  onChange={(e) => setAuthProvider(e.target.value as typeof authProvider)}
+                >
+                  <option value="password">Email / Password</option>
+                </select>
+              </label>
+              <label>
+                Email
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="email@example.com"
+                  autoComplete="username"
+                />
+              </label>
+              <label>
+                Password
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="password"
+                  autoComplete="current-password"
+                />
+              </label>
+              <label>
+                TZ Offset (minutes)
+                <input
+                  value={tzOffset}
+                  onChange={(e) => setTzOffset(e.target.value)}
+                  placeholder="540"
+                />
+              </label>
+              <div className="actions">
+                <button onClick={handleLogin} disabled={isAuthLoading || !email.trim() || !password}>
+                  {isAuthLoading ? "Logging in..." : "Login"}
+                </button>
+                <Link className="pill-link" href="/top">
+                  Back
+                </Link>
+              </div>
+              {authError && <p className="error">{authError}</p>}
+            </>
+          ) : (
+            <>
+              <p className="muted">ログイン済みです。ダッシュボードへ移動できます。</p>
+              <div className="actions">
+                <button onClick={() => router.push("/top")}>Go to Dashboard</button>
+                <button onClick={logout}>Logout</button>
+              </div>
+            </>
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,201 +1,46 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { AccessSettingsFooter } from "./_components/AccessSettingsFooter";
-import { CategoryCard } from "./_components/CategoryCard";
+import Link from "next/link";
 import { PageHero } from "./_components/PageHero";
 import { useClientAuth } from "./_hooks/useClientAuth";
-import { getTodayString } from "./_lib/date";
-import { getOverdueReferenceDate } from "./_lib/deadline";
-
-type Task = {
-  id: string;
-  title: string;
-  note: string;
-  date: string | null;
-  deadline: string | null;
-  someday: boolean;
-  completedAt: string | null;
-  archivedAt: string | null;
-  createdAt: string | null;
-  areaId: string | null;
-  projectId: string | null;
-};
-
-type DataState<T> =
-  | { status: "idle" }
-  | { status: "loading" }
-  | { status: "error"; message: string }
-  | { status: "ready"; items: T[] };
-
-type Area = {
-  id: string;
-  name: string;
-  sort_key?: string | null;
-};
-
-function splitOverdue(items: Task[], today: string) {
-  let overdue = 0;
-  let rest = 0;
-  for (const item of items) {
-    if (item.completedAt) continue;
-    const refDate = getOverdueReferenceDate(item.date, item.deadline);
-    if (refDate && refDate < today) {
-      overdue += 1;
-    } else {
-      rest += 1;
-    }
-  }
-  return { overdue, rest };
-}
 
 export default function HomePage() {
-  const {
-    accessToken,
-    authProvider,
-    setAuthProvider,
-    isAuthenticated,
-    isAuthLoading,
-    authError,
-    login,
-    logout,
-    tzOffset,
-    setTzOffset,
-    headers,
-    authedFetch,
-  } = useClientAuth();
-  const [today, setToday] = useState<DataState<Task>>({ status: "idle" });
-  const [inbox, setInbox] = useState<DataState<Task>>({ status: "idle" });
-  const [areas, setAreas] = useState<DataState<Area>>({ status: "idle" });
-  const [loginEmail, setLoginEmail] = useState("");
-  const [loginPassword, setLoginPassword] = useState("");
-
-  const accessReady = accessToken.trim().length > 0;
-  const canFetch = accessReady;
-
-  const fetchView = async <T,>(path: string, setter: (state: DataState<T>) => void) => {
-    setter({ status: "loading" });
-    try {
-      const res = await authedFetch(path, { headers });
-      const json = await res.json();
-      if (!res.ok) {
-        setter({ status: "error", message: json?.error?.message ?? "Request failed" });
-        return;
-      }
-      setter({ status: "ready", items: (json.items ?? []) as T[] });
-    } catch (err) {
-      setter({ status: "error", message: err instanceof Error ? err.message : "Request failed" });
-    }
-  };
-
-  const refreshAll = () => {
-    if (!canFetch) return;
-    fetchView("/api/today", setToday);
-    fetchView("/api/inbox", setInbox);
-    fetchView("/api/areas", setAreas);
-  };
-
-  useEffect(() => {
-    if (canFetch) refreshAll();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [canFetch]);
-
-  const todayDate = useMemo(() => {
-    const offset = Number(tzOffset);
-    return getTodayString(Number.isFinite(offset) ? offset : 0);
-  }, [tzOffset]);
-
-  const todayCount =
-    today.status === "ready" ? splitOverdue(today.items, todayDate) : { overdue: 0, rest: 0 };
-  const inboxCount =
-    inbox.status === "ready" ? splitOverdue(inbox.items, todayDate) : { overdue: 0, rest: 0 };
-
-  const handleLogin = async () => {
-    const ok = await login(loginEmail, loginPassword);
-    if (ok) {
-      setLoginPassword("");
-      refreshAll();
-    }
-  };
+  const { isAuthenticated } = useClientAuth();
 
   return (
     <main>
       <PageHero
         eyebrow="Nextstep"
-        title="Daily dashboard"
-        lead="Today と Inbox の件数だけを表示。エリアは同列に並べて確認できます。"
+        title="Welcome"
+        lead="公開版をご利用いただくにはログインしてください。"
       />
 
       <section className="grid">
-        <CategoryCard
-          title="Today"
-          href="/today"
-          status={today.status}
-          detail={`Overdue ${todayCount.overdue} / Today ${todayCount.rest}`}
-          showDetail={today.status === "ready"}
-          icon={<i className="fa-solid fa-star icon-today" aria-hidden />}
-        />
-        <CategoryCard
-          title="Upcoming"
-          href="/upcoming"
-          status={today.status}
-          icon={<i className="fa-solid fa-calendar icon-upcoming" aria-hidden />}
-        />
-        <CategoryCard
-          title="Anytime"
-          href="/anytime"
-          status={today.status}
-          icon={<i className="fa-brands fa-stack-overflow icon-anytime" aria-hidden />}
-        />
-        <CategoryCard
-          title="Someday"
-          href="/someday"
-          status={today.status}
-          icon={<i className="fa-solid fa-archive icon-someday" aria-hidden />}
-        />
-        <CategoryCard
-          title="Logbook"
-          href="/logbook"
-          status={today.status}
-          icon={<i className="fa-solid fa-book icon-logbook" aria-hidden />}
-        />
-        <CategoryCard
-          title="Inbox"
-          href="/inbox"
-          status={inbox.status}
-          detail={`Overdue ${inboxCount.overdue} / Others ${inboxCount.rest}`}
-          showDetail={inbox.status === "ready"}
-          icon={<i className="fa-solid fa-inbox icon-inbox" aria-hidden />}
-        />
-        {areas.status === "loading" && <CategoryCard title="Areas" status="loading" />}
-        {areas.status === "error" && (
-          <CategoryCard title="Areas" status="error" detail="Failed to load areas" showDetail />
-        )}
-        {areas.status === "ready" && areas.items.length === 0 && (
-          <CategoryCard title="Areas" status="ready" detail="No areas" showDetail />
-        )}
-        {areas.status === "ready" &&
-          areas.items.map((area) => (
-            <CategoryCard key={area.id} title={area.name} href={`/areas/${area.id}`} />
-          ))}
+        <div className="panel">
+          <h2 className="with-icon">
+            <span className="title-icon">
+              <i className="fa-solid fa-right-to-bracket" aria-hidden />
+            </span>
+            ログインが必要です
+          </h2>
+          <p className="muted">
+            {isAuthenticated
+              ? "ログイン済みです。ダッシュボードへ進んでください。"
+              : "ログインページから認証してください。"}
+          </p>
+          <div className="actions">
+            {!isAuthenticated ? (
+              <Link className="pill-link" href="/login">
+                Login
+              </Link>
+            ) : (
+              <Link className="pill-link" href="/top">
+                Go to Top
+              </Link>
+            )}
+          </div>
+        </div>
       </section>
-      <AccessSettingsFooter
-        authProvider={authProvider}
-        setAuthProvider={setAuthProvider}
-        loginEmail={loginEmail}
-        setLoginEmail={setLoginEmail}
-        loginPassword={loginPassword}
-        setLoginPassword={setLoginPassword}
-        onLogin={handleLogin}
-        onLogout={logout}
-        isAuthenticated={isAuthenticated}
-        isAuthLoading={isAuthLoading}
-        authError={authError}
-        tzOffset={tzOffset}
-        setTzOffset={setTzOffset}
-        onRefresh={refreshAll}
-        canFetch={canFetch}
-      />
     </main>
   );
 }

--- a/app/top/page.tsx
+++ b/app/top/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AccessSettingsFooter } from "../_components/AccessSettingsFooter";
+import { CategoryCard } from "../_components/CategoryCard";
+import { PageHero } from "../_components/PageHero";
+import { useClientAuth } from "../_hooks/useClientAuth";
+import { getTodayString } from "../_lib/date";
+import { getOverdueReferenceDate } from "../_lib/deadline";
+
+type Task = {
+  id: string;
+  title: string;
+  note: string;
+  date: string | null;
+  deadline: string | null;
+  someday: boolean;
+  completedAt: string | null;
+  archivedAt: string | null;
+  createdAt: string | null;
+  areaId: string | null;
+  projectId: string | null;
+};
+
+type DataState<T> =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; items: T[] };
+
+type Area = {
+  id: string;
+  name: string;
+  sort_key?: string | null;
+};
+
+function splitOverdue(items: Task[], today: string) {
+  let overdue = 0;
+  let rest = 0;
+  for (const item of items) {
+    if (item.completedAt) continue;
+    const refDate = getOverdueReferenceDate(item.date, item.deadline);
+    if (refDate && refDate < today) {
+      overdue += 1;
+    } else {
+      rest += 1;
+    }
+  }
+  return { overdue, rest };
+}
+
+export default function HomePage() {
+  const {
+    accessToken,
+    authProvider,
+    setAuthProvider,
+    isAuthenticated,
+    isAuthLoading,
+    authError,
+    login,
+    logout,
+    tzOffset,
+    setTzOffset,
+    headers,
+    authedFetch,
+  } = useClientAuth();
+  const [today, setToday] = useState<DataState<Task>>({ status: "idle" });
+  const [inbox, setInbox] = useState<DataState<Task>>({ status: "idle" });
+  const [areas, setAreas] = useState<DataState<Area>>({ status: "idle" });
+  const [loginEmail, setLoginEmail] = useState("");
+  const [loginPassword, setLoginPassword] = useState("");
+
+  const accessReady = accessToken.trim().length > 0;
+  const canFetch = accessReady;
+
+  const fetchView = async <T,>(path: string, setter: (state: DataState<T>) => void) => {
+    setter({ status: "loading" });
+    try {
+      const res = await authedFetch(path, { headers });
+      const json = await res.json();
+      if (!res.ok) {
+        setter({ status: "error", message: json?.error?.message ?? "Request failed" });
+        return;
+      }
+      setter({ status: "ready", items: (json.items ?? []) as T[] });
+    } catch (err) {
+      setter({ status: "error", message: err instanceof Error ? err.message : "Request failed" });
+    }
+  };
+
+  const refreshAll = () => {
+    if (!canFetch) return;
+    fetchView("/api/today", setToday);
+    fetchView("/api/inbox", setInbox);
+    fetchView("/api/areas", setAreas);
+  };
+
+  useEffect(() => {
+    if (canFetch) refreshAll();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canFetch]);
+
+  const todayDate = useMemo(() => {
+    const offset = Number(tzOffset);
+    return getTodayString(Number.isFinite(offset) ? offset : 0);
+  }, [tzOffset]);
+
+  const todayCount =
+    today.status === "ready" ? splitOverdue(today.items, todayDate) : { overdue: 0, rest: 0 };
+  const inboxCount =
+    inbox.status === "ready" ? splitOverdue(inbox.items, todayDate) : { overdue: 0, rest: 0 };
+
+  const handleLogin = async () => {
+    const ok = await login(loginEmail, loginPassword);
+    if (ok) {
+      setLoginPassword("");
+      refreshAll();
+    }
+  };
+
+  return (
+    <main>
+      <PageHero
+        eyebrow="Nextstep"
+        title="Daily dashboard"
+        lead="Today と Inbox の件数だけを表示。エリアは同列に並べて確認できます。"
+      />
+
+      <section className="grid">
+        <CategoryCard
+          title="Today"
+          href="/today"
+          status={today.status}
+          detail={`Overdue ${todayCount.overdue} / Today ${todayCount.rest}`}
+          showDetail={today.status === "ready"}
+          icon={<i className="fa-solid fa-star icon-today" aria-hidden />}
+        />
+        <CategoryCard
+          title="Upcoming"
+          href="/upcoming"
+          status={today.status}
+          icon={<i className="fa-solid fa-calendar icon-upcoming" aria-hidden />}
+        />
+        <CategoryCard
+          title="Anytime"
+          href="/anytime"
+          status={today.status}
+          icon={<i className="fa-brands fa-stack-overflow icon-anytime" aria-hidden />}
+        />
+        <CategoryCard
+          title="Someday"
+          href="/someday"
+          status={today.status}
+          icon={<i className="fa-solid fa-archive icon-someday" aria-hidden />}
+        />
+        <CategoryCard
+          title="Logbook"
+          href="/logbook"
+          status={today.status}
+          icon={<i className="fa-solid fa-book icon-logbook" aria-hidden />}
+        />
+        <CategoryCard
+          title="Inbox"
+          href="/inbox"
+          status={inbox.status}
+          detail={`Overdue ${inboxCount.overdue} / Others ${inboxCount.rest}`}
+          showDetail={inbox.status === "ready"}
+          icon={<i className="fa-solid fa-inbox icon-inbox" aria-hidden />}
+        />
+        {areas.status === "loading" && <CategoryCard title="Areas" status="loading" />}
+        {areas.status === "error" && (
+          <CategoryCard title="Areas" status="error" detail="Failed to load areas" showDetail />
+        )}
+        {areas.status === "ready" && areas.items.length === 0 && (
+          <CategoryCard title="Areas" status="ready" detail="No areas" showDetail />
+        )}
+        {areas.status === "ready" &&
+          areas.items.map((area) => (
+            <CategoryCard key={area.id} title={area.name} href={`/areas/${area.id}`} />
+          ))}
+      </section>
+      <AccessSettingsFooter
+        authProvider={authProvider}
+        setAuthProvider={setAuthProvider}
+        loginEmail={loginEmail}
+        setLoginEmail={setLoginEmail}
+        loginPassword={loginPassword}
+        setLoginPassword={setLoginPassword}
+        onLogin={handleLogin}
+        onLogout={logout}
+        isAuthenticated={isAuthenticated}
+        isAuthLoading={isAuthLoading}
+        authError={authError}
+        tzOffset={tzOffset}
+        setTzOffset={setTzOffset}
+        onRefresh={refreshAll}
+        canFetch={canFetch}
+      />
+    </main>
+  );
+}

--- a/docs/L2_development/architecture_design.md
+++ b/docs/L2_development/architecture_design.md
@@ -20,14 +20,16 @@
 根拠: `app/`, `app/_components/`, `app/_hooks/`, `app/_lib/`, `db/`, `docs/`, `tests/`
 
 ## フロントエンド
-- `app/page.tsx`: ダッシュボード（Today/Inbox/Areas の件数やリンク）
+- `app/page.tsx`: 公開トップ（ログイン導線）
+- `app/top/page.tsx`: ダッシュボード（Today/Inbox/Areas の件数やリンク）
+- `app/login/page.tsx`: ログインページ
 - `app/(views)/[view]/page.tsx`: Today/Upcoming/Anytime/Someday/Logbook/Inbox の一覧画面
 - `app/areas/[areaId]/page.tsx`, `app/projects/[projectId]/page.tsx`: Area/Project の詳細画面
 - 共通 UI は `app/_components/`（`CategoryCard`, `PageHero`, `PageMidHeader`, `AccessSettingsFooter`）に集約
 - 共通状態 Hook は `app/_hooks/useStoredState.ts`、トークン状態と TZ ヘッダ生成は `app/_hooks/useClientAuth.ts` に集約
 - 日付系ユーティリティは `app/_lib/date.ts` に集約
 
-根拠: `app/page.tsx`, `app/(views)/[view]/page.tsx`, `app/areas/[areaId]/page.tsx`, `app/projects/[projectId]/page.tsx`, `app/_components/AccessSettingsFooter.tsx`, `app/_components/CategoryCard.tsx`, `app/_components/PageHero.tsx`, `app/_components/PageMidHeader.tsx`, `app/_hooks/useClientAuth.ts`, `app/_hooks/useStoredState.ts`, `app/_lib/date.ts`
+根拠: `app/page.tsx`, `app/top/page.tsx`, `app/login/page.tsx`, `app/(views)/[view]/page.tsx`, `app/areas/[areaId]/page.tsx`, `app/projects/[projectId]/page.tsx`, `app/_components/AccessSettingsFooter.tsx`, `app/_components/CategoryCard.tsx`, `app/_components/PageHero.tsx`, `app/_components/PageMidHeader.tsx`, `app/_hooks/useClientAuth.ts`, `app/_hooks/useStoredState.ts`, `app/_lib/date.ts`
 
 ## バックエンド（API）
 - 認証: `Authorization: Bearer <token>` または `x-access-token` を受け取り、Supabase Auth で検証。

--- a/docs/L3_implementation/specification_summary.md
+++ b/docs/L3_implementation/specification_summary.md
@@ -86,9 +86,12 @@
 根拠: `db/migrations/0001_init.sql`, `db/maintenance/0003_archive_flow.sql`, `db/maintenance/0004_add_task_deadline.sql`, `scripts/db_migrate.sh`, `scripts/db_backup.sh`, `scripts/db_rollback.sh`
 
 ## フロントエンドの実装仕様
-- ダッシュボードは Today/Inbox の件数と Area を表示。
+- `app/page.tsx` は公開トップとして「ログインが必要です」カードのみ表示する。
+- ダッシュボードは `app/top/page.tsx` で Today/Inbox の件数と Area を表示する。
+- `app/login/page.tsx` はログイン成功後に `/top` へ遷移する。
 - ダッシュボードの Today/Inbox detail（`Overdue x / ...`）は超過基準日（`deadline ?? date`）で集計する。
 - 各ビューは `/api/{view}` を取得して表示。
+- `PageMidHeader` の既定リンク先は `/top`。
 - `app/(views)/[view]/page.tsx` の各カテゴリ画面では、`PageMidHeader` 直下に「現在の view に対応する単一の `CategoryCard`」を表示する。
 - 上記 `CategoryCard` は `PageMidHeader` の直下でスクロール追従（sticky）し、Today/Inbox の場合はダッシュボード同様の detail（Overdue/Today, Overdue/Others）を表示する。
 - `app/(views)/[view]/page.tsx` の No Group セクション（area/project 未所属タスク）は、専用クラスでタスク行左余白を調整し、Project/Area 見出しアイコンの左端と揃える。
@@ -97,13 +100,13 @@
 - `authProvider` は現状 `password` のみ実装され、認証方式の拡張ポイントとして扱う。
 - 画面横断で再利用する UI は `app/_components` に集約する（`CategoryCard`, `PageHero`, `PageMidHeader`, `AccessSettingsFooter`）。
 - `localStorage` 読み書きは `app/_hooks/useStoredState.ts`（`useStoredValue`, `useStoredJson`）を利用する。
-- トークン状態（`accessToken`/`refreshToken`/`tzOffset`）と `x-tz-offset-minutes` ヘッダ生成は `app/_hooks/useClientAuth.ts` に共通化し、`app/page.tsx` / `app/(views)/[view]/page.tsx` / `app/areas/[areaId]/page.tsx` / `app/projects/[projectId]/page.tsx` が利用する。
+- トークン状態（`accessToken`/`refreshToken`/`tzOffset`）と `x-tz-offset-minutes` ヘッダ生成は `app/_hooks/useClientAuth.ts` に共通化し、`app/page.tsx` / `app/top/page.tsx` / `app/login/page.tsx` / `app/(views)/[view]/page.tsx` / `app/areas/[areaId]/page.tsx` / `app/projects/[projectId]/page.tsx` が利用する。
 - `useStoredValue` は初回 hydration 完了前に `localStorage` へ書き戻さない（初期空文字で既存 token を上書きしない）。
 - 日付表示の共通計算は `app/_lib/date.ts`（`DEFAULT_TZ_OFFSET`, `getTodayString`, `getScheduleLabel`）を利用する。
 - `app/(views)/[view]/page.tsx` は `today/anytime/someday` のメタ情報（`areas/projects`）を token 単位でキャッシュし、View 間遷移時の重複取得を抑制する（`Refresh` は強制再取得）。
 - クライアントの API 呼び出しは `useClientAuth` が返す `authedFetch`（内部で `useAuthedFetch` / `fetchWithAutoRefresh` を利用）を通し、`401` 受信時は `refreshToken` で 1 回だけ再発行後に再試行する。
 
-根拠: `app/page.tsx`, `app/(views)/[view]/page.tsx`, `app/areas/[areaId]/page.tsx`, `app/projects/[projectId]/page.tsx`, `app/_components/AccessSettingsFooter.tsx`, `app/_components/CategoryCard.tsx`, `app/_components/PageHero.tsx`, `app/_components/PageMidHeader.tsx`, `app/_hooks/useClientAuth.ts`, `app/_hooks/useStoredState.ts`, `app/_lib/date.ts`, `app/_lib/deadline.ts`, `app/globals.css`
+根拠: `app/page.tsx`, `app/top/page.tsx`, `app/login/page.tsx`, `app/(views)/[view]/page.tsx`, `app/areas/[areaId]/page.tsx`, `app/projects/[projectId]/page.tsx`, `app/_components/AccessSettingsFooter.tsx`, `app/_components/CategoryCard.tsx`, `app/_components/PageHero.tsx`, `app/_components/PageMidHeader.tsx`, `app/_hooks/useClientAuth.ts`, `app/_hooks/useStoredState.ts`, `app/_lib/date.ts`, `app/_lib/deadline.ts`, `app/globals.css`
 
 ## Task 編集 UI のフォーカス挙動
 - タスク編集時は最後にタップした入力（Title / Note）を `lastFocusRef` で記録し、編集有効化時に該当の入力へフォーカスを移す。

--- a/tests/auth_context_shared_usage.test.ts
+++ b/tests/auth_context_shared_usage.test.ts
@@ -8,6 +8,8 @@ function read(path: string) {
 describe("shared auth context usage", () => {
   const targets = [
     "../app/page.tsx",
+    "../app/top/page.tsx",
+    "../app/login/page.tsx",
     "../app/(views)/[view]/page.tsx",
     "../app/areas/[areaId]/page.tsx",
     "../app/projects/[projectId]/page.tsx",

--- a/tests/smoke/app_entry.test.ts
+++ b/tests/smoke/app_entry.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
 import HomePage from "../../app/page";
+import LoginPage from "../../app/login/page";
 import { nonEmptyString } from "../../app/api/_helpers";
 import { error } from "../../app/api/_utils";
 
 describe("smoke: entrypoints", () => {
   it("app page exports a component", () => {
     expect(typeof HomePage).toBe("function");
+  });
+
+  it("login page exports a component", () => {
+    expect(typeof LoginPage).toBe("function");
   });
 
   it("api helpers export functions", () => {


### PR DESCRIPTION
## 概要
公開導線を明確化するため、`/` をログイン導線ページに再定義し、ダッシュボード本体を `/top` へ分離しました。あわせて戻るリンクを `/top` に統一しました。

## 変更内容
- `app/login/page.tsx` 新規追加
  - 専用ログインUI
  - ログイン成功時の遷移先を `/top` に設定
- `app/top/page.tsx` 新規追加（`app/page.tsx` から分離）
  - ダッシュボード本体（Today/Inbox/Areas など）を配置
- `app/page.tsx` 再定義
  - 「ログインが必要です」カードのみ表示
  - 未ログイン時は `/login`、ログイン済み時は `/top` への導線表示
- `app/_components/PageMidHeader.tsx`
  - 既定戻り先を `/top` に変更
- `app/(views)/[view]/page.tsx`
  - Not Found 時の Back リンクを `/top` へ変更
- `.gitignore`
  - `.env.zwc`, `supabase` を追加

## テスト
- `npm run typecheck`
- `npx vitest run tests/smoke/app_entry.test.ts tests/auth_context_shared_usage.test.ts`

## Docs 同期
- `docs/L2_development/architecture_design.md`
- `docs/L3_implementation/specification_summary.md`

